### PR TITLE
migrated vuex calls to enums

### DIFF
--- a/src/components/ConnectButton.vue
+++ b/src/components/ConnectButton.vue
@@ -22,6 +22,7 @@
 </template>
 
 <script setup lang="ts">
+import { Web3Actions, Web3Getters } from "@/types/store/Web3";
 import { ref, onMounted, computed } from "vue";
 import { useStore } from "vuex";
 import { key } from "../store";
@@ -29,20 +30,20 @@ import { key } from "../store";
 const store = useStore(key);
 console.log("store", store);
 
-const getActiveAccount = computed(() => store.getters["web3/getActiveAccount"]);
-const getWeb3Modal = computed(() => store.getters["web3/getWeb3Modal"]);
-const isUserConnected = computed(() => store.getters["web3/isUserConnected"]);
+const getActiveAccount = computed(() => store.getters[`web3/${Web3Getters.getActiveAccount}`]);
+const getWeb3Modal = computed(() => store.getters[`web3/${Web3Getters.getWeb3Modal}`]);
+const isUserConnected = computed(() => store.getters[`web3/${Web3Getters.isUserConnected}`]);
 
 async function connectWeb3Modal() {
-  await store.dispatch("web3/connectWeb3Modal");
+  await store.dispatch(`web3/${Web3Actions.connectWeb3Modal}`);
 }
 
 async function disconnectWeb3Modal() {
-  await store.dispatch("web3/disconnectWeb3Modal");
+  await store.dispatch(`web3/${Web3Actions.disconnectWeb3Modal}`);
 }
 
 onMounted(async () => {
-  await store.dispatch("web3/initWeb3Modal");
-  await store.dispatch("web3/ethereumListener");
+  await store.dispatch(`web3/${Web3Actions.initWeb3Modal}`);
+  await store.dispatch(`web3/${Web3Actions.ethereumListener}`);
 });
 </script>

--- a/src/types/store/Web3.ts
+++ b/src/types/store/Web3.ts
@@ -1,0 +1,42 @@
+import { providers } from "ethers";
+import Web3Modal from "web3modal";
+
+export enum Web3Getters {
+    getActiveAccount = 'getActiveAccount',
+    getActiveBalanceWei = 'getActiveBalanceWei',
+    getActiveBalanceEth = 'getActiveBalanceEth',
+    getChainId = 'getChainId',
+    getChainName = 'getChainName',
+    getProviderEthers = 'getProviderEthers',
+    getWeb3Modal = 'getWeb3Modal',
+    isUserConnected = 'isUserConnected'
+}
+
+export enum Web3Actions {
+    initWeb3Modal = 'initWeb3Modal',
+    connectWeb3Modal = 'connectWeb3Modal',
+    disconnectWeb3Modal = 'disconnectWeb3Modal',
+    ethereumListener = 'ethereumListener',
+    fetchActiveBalance = 'fetchActiveBalance',
+}
+
+export enum Web3Mutations {
+    disconnectWallet = 'disconnectWallet',
+    setActiveAccount = 'setActiveAccount',
+    setActiveBalance = 'setActiveBalance',
+    setChainData = 'setChainData',
+    setEthersProvider = 'setEthersProvider',
+    setIsConnected = 'setIsConnected',
+    setWeb3ModalInstance = 'setWeb3ModalInstance',
+}
+
+export interface Web3State {
+    activeAccount: null | string,
+    activeBalance: number,
+    chainId: null | string,
+    chainName: null | string,
+    providerEthers: null | providers.Provider, // this is "provider" for Ethers.js
+    isConnected: boolean,
+    providerW3m: null | any, // this is "provider" from Web3Modal
+    web3Modal: null | Web3Modal
+}


### PR DESCRIPTION
Summary of changes:

1. Created types folder with Enums to avoid string typos. Calling Vuex actions, mutations or getters from components should be done using `Action.ActionName` or equivalent.

2. Refactored store to use enums, added Vuex tree types to actions, getters, mutations

3. Changed component button to use enums

We can further improve typing by building the interface ahead-of-time but this is a relatively low cost addition that saves a lot of easy-to-make-mistakes